### PR TITLE
Enhanced font support and Flavor Text for hero templates

### DIFF
--- a/legedit/cardtypes/hero_common/template.xml
+++ b/legedit/cardtypes/hero_common/template.xml
@@ -366,7 +366,24 @@ subnameeditable="false"
  rectyarray="780,780,880,880,965,1000"
  debug="false"
  />
-
+ 
+<scrollingtextarea
+ name="Flavor Text"
+ alignmenthorizontal="left"
+ alignmentvertical="top"
+ allowchange="true"
+ defaultvalue=""
+ colour="#000000"
+ textsize="20"
+ fontstyle="2"
+ startx="150"
+ endx="500"
+ starty="200"
+ endy="850"
+ direction="up"
+ debug="false"
+ />
+ 
 <property
  name="Number in Deck"
  property="numberindeck"

--- a/legedit/cardtypes/hero_common_transformed/template.xml
+++ b/legedit/cardtypes/hero_common_transformed/template.xml
@@ -368,6 +368,23 @@ subnameeditable="false"
  rectyarray="780,780,880,880,965,1000"
  debug="false"
  />
+ 
+<scrollingtextarea
+ name="Flavor Text"
+ alignmenthorizontal="left"
+ alignmentvertical="top"
+ allowchange="true"
+ defaultvalue=""
+ colour="#000000"
+ textsize="20"
+ fontstyle="2"
+ startx="150"
+ endx="500"
+ starty="200"
+ endy="850"
+ direction="up"
+ debug="false"
+/>
 
 <property
  name="Number in Deck"

--- a/legedit/cardtypes/hero_rare/template.xml
+++ b/legedit/cardtypes/hero_rare/template.xml
@@ -337,6 +337,23 @@ subnameeditable="false"
  rectyarray="780,780,880,880,1010,1010"
  debug="false"
  />
+ 
+<scrollingtextarea
+ name="Flavor Text"
+ alignmenthorizontal="left"
+ alignmentvertical="top"
+ allowchange="true"
+ defaultvalue=""
+ colour="#000000"
+ textsize="20"
+ fontstyle="2"
+ startx="150"
+ endx="500"
+ starty="200"
+ endy="850"
+ direction="up"
+ debug="false"
+/>
 
 <property
  name="Number in Deck"

--- a/legedit/cardtypes/hero_rare_transformed/template.xml
+++ b/legedit/cardtypes/hero_rare_transformed/template.xml
@@ -340,6 +340,23 @@ subnameeditable="false"
  debug="false"
  />
 
+<scrollingtextarea
+ name="Flavor Text"
+ alignmenthorizontal="left"
+ alignmentvertical="top"
+ allowchange="true"
+ defaultvalue=""
+ colour="#000000"
+ textsize="20"
+ fontstyle="2"
+ startx="150"
+ endx="500"
+ starty="200"
+ endy="850"
+ direction="up"
+ debug="false"
+/>
+
 <property
  name="Number in Deck"
  property="numberindeck"

--- a/legedit/cardtypes/hero_uncommon/template.xml
+++ b/legedit/cardtypes/hero_uncommon/template.xml
@@ -367,6 +367,23 @@ subnameeditable="false"
  debug="false"
  />
 
+<scrollingtextarea
+ name="Flavor Text"
+ alignmenthorizontal="left"
+ alignmentvertical="top"
+ allowchange="true"
+ defaultvalue=""
+ colour="#000000"
+ textsize="20"
+ fontstyle="2"
+ startx="150"
+ endx="500"
+ starty="200"
+ endy="850"
+ direction="up"
+ debug="false"
+/>
+ 
 <property
  name="Number in Deck"
  property="numberindeck"

--- a/legedit/cardtypes/hero_uncommon_transformed/template.xml
+++ b/legedit/cardtypes/hero_uncommon_transformed/template.xml
@@ -369,6 +369,23 @@ subnameeditable="false"
  debug="false"
  />
 
+<scrollingtextarea
+ name="Flavor Text"
+ alignmenthorizontal="left"
+ alignmentvertical="top"
+ allowchange="true"
+ defaultvalue=""
+ colour="#000000"
+ textsize="20"
+ fontstyle="2"
+ startx="150"
+ endx="500"
+ starty="200"
+ endy="850"
+ direction="up"
+ debug="false"
+/>
+
 <property
  name="Number in Deck"
  property="numberindeck"

--- a/src/legedit2/cardtype/CardType.java
+++ b/src/legedit2/cardtype/CardType.java
@@ -1011,6 +1011,11 @@ public class CardType extends ItemType implements Cloneable {
 				element.fontNameBold = node.getAttributes().getNamedItem("fontnamebold").getNodeValue();
 			}
 			
+			if (node.getAttributes().getNamedItem("fontstyle") != null)
+			{
+				element.fontStyle = Integer.parseInt(node.getAttributes().getNamedItem("fontstyle").getNodeValue());
+			}
+
 			if (node.getAttributes().getNamedItem("textsize") != null)
 			{
 				element.textSize = Integer.parseInt(node.getAttributes().getNamedItem("textsize").getNodeValue());

--- a/src/legedit2/cardtype/CardType.java
+++ b/src/legedit2/cardtype/CardType.java
@@ -711,6 +711,11 @@ public class CardType extends ItemType implements Cloneable {
 				element.fontName = node.getAttributes().getNamedItem("fontname").getNodeValue();
 			}
 			
+			if (node.getAttributes().getNamedItem("fontstyle") != null)
+			{
+				element.fontStyle = Integer.parseInt(node.getAttributes().getNamedItem("fontstyle").getNodeValue());
+			}
+
 			if (node.getAttributes().getNamedItem("textsize") != null)
 			{
 				element.textSize = Integer.parseInt(node.getAttributes().getNamedItem("textsize").getNodeValue());

--- a/src/legedit2/cardtype/ElementCardName.java
+++ b/src/legedit2/cardtype/ElementCardName.java
@@ -24,6 +24,7 @@ public class ElementCardName extends CustomElement implements Cloneable {
 
 	public enum HIGHLIGHT {BANNER, BLUR, BANNER_BLUR, NONE}
 	
+	// global card name settings
 	public String defaultValue;
 	public boolean includeSubname;
 	public String subnameText;
@@ -39,24 +40,52 @@ public class ElementCardName extends CustomElement implements Cloneable {
 	public boolean blurDouble;
 	public int blurExpand;
 	public Color highlightColour;
-	public int textSize;
-	public int subnameSize;
-	public String fontName;
-	public int fontStyle;
 	public boolean uppercase;
 	public HIGHLIGHT highlight = HIGHLIGHT.NONE;
 	public int subnameGap = -1;
-	
-	public String value;
-	public String namePrefix = "";
-	public String nameSuffix = "";
-	public String subnameValue;
-	private String subnamePrefix = "";
-	private String subnameSuffix = "";
-	
 	private JTextField cardNameField;
 	private JTextField cardSubNameField;
 	
+	// card name specific settings
+	public String value;
+	public String fontName;
+	public int fontStyle;
+	public int textSize;
+	public String namePrefix = "";
+	public String nameSuffix = "";
+	
+	// sub name specific settings
+	public String subnameValue;
+	public String subnameFontName;
+	public int subnameFontStyle;
+	public int subnameSize;
+	private String subnamePrefix = "";
+	private String subnameSuffix = "";	
+
+	
+	private Font createFont(String fontName, int fontStyle, int textSize)
+	{
+		Font newFont = null;
+    	try
+    	{
+    		newFont = Font.createFont(Font.TRUETYPE_FONT, new File("legedit" + File.separator + "fonts" + File.separator + "Percolator.otf"));
+    		newFont = newFont.deriveFont((float)getPercentage(textSize, getScale()));
+    	}
+    	catch (Exception e)
+    	{
+    		e.printStackTrace();
+    		
+    		newFont = new Font("Percolator", Font.PLAIN, getPercentage(textSize, getScale()));
+    	}
+    	
+    	if (fontName != null)
+		{
+    		newFont = new Font(fontName, fontStyle, getPercentage(textSize, getScale()));
+		}
+    	
+    	return newFont;
+    }
+
 	public void drawElement(Graphics2D g)
 	{
 		if (getValue() != null)
@@ -70,23 +99,9 @@ public class ElementCardName extends CustomElement implements Cloneable {
 				g2.setColor(colour);
 			}
 			
-			Font font = null;
-	    	try
-	    	{
-	    	font = Font.createFont(Font.TRUETYPE_FONT, new File("legedit" + File.separator + "fonts" + File.separator + "Percolator.otf"));
-	        font = font.deriveFont((float)getPercentage(textSize, getScale()));
-	    	}
-	    	catch (Exception e)
-	    	{
-	    		e.printStackTrace();
-	    		
-	    		font = new Font("Percolator", Font.PLAIN, getPercentage(textSize,getScale()));
-	    	}
-	    	if (fontName != null)
-    		{
-    			font = new Font(fontName, fontStyle, getPercentage(textSize, getScale()));
-    		}
+			Font font = createFont(fontName, fontStyle, textSize);
 	        g2.setFont(font);
+	        
 	        FontMetrics metrics = g2.getFontMetrics(font);
 	        int stringLength = SwingUtilities.computeStringWidth(metrics, getValueForDraw());
 	        
@@ -129,7 +144,7 @@ public class ElementCardName extends CustomElement implements Cloneable {
 	        Font fontSubname = null;
 	        if (includeSubname)
 	        {
-	        	fontSubname = font.deriveFont((float)getPercentage(subnameSize, getScale()));
+	        	fontSubname = createFont(subnameFontName, subnameFontStyle, subnameSize);
 		        
 		        g2.setFont(fontSubname);
 		        metrics = g2.getFontMetrics(fontSubname);
@@ -150,8 +165,7 @@ public class ElementCardName extends CustomElement implements Cloneable {
 		        g2.setFont(font);
 		        metrics = g2.getFontMetrics(font);
 		        
-		        bannerEnd = yModifiedSubname + getPercentage(getPercentage(CustomCardMaker.cardHeight, getScale()), 0.015d);
-		        
+		        bannerEnd = yModifiedSubname + getPercentage(getPercentage(CustomCardMaker.cardHeight, getScale()), 0.015d);		        
 	        }
 	        
 	        
@@ -389,9 +403,12 @@ public class ElementCardName extends CustomElement implements Cloneable {
 		
 		str += "<cardname name=\"" + replaceNonXMLCharacters(name) + "\" "
 				+ "value=\""+replaceNonXMLCharacters(getValue())+"\" "
-				+ "subnameValue=\"" + replaceNonXMLCharacters(getSubnameValue()) + "\" "
-				+ (fontName == null ? " " : "fontname=\""+replaceNonXMLCharacters(fontName)+"\" ")
+				+ (fontName == null ? "" : "fontname=\""+replaceNonXMLCharacters(fontName)+"\" ")
+				+ (fontName == null ? "" : "fontstyle=\""+fontStyle+"\" ")
 				+ "textsize=\""+textSize+"\" "
+				+ "subnameValue=\"" + replaceNonXMLCharacters(getSubnameValue()) + "\" "
+				+ (subnameFontName == null ? "" : "subnamefontname=\""+replaceNonXMLCharacters(subnameFontName)+"\" ")
+				+ (subnameFontName == null ? "" : "subnamefontstyle=\""+subnameFontStyle+"\" ")
 				+ "subnamesize=\""+subnameSize+"\" />\n";
 		
 		return str;
@@ -404,11 +421,31 @@ public class ElementCardName extends CustomElement implements Cloneable {
 			return;
 		}
 		
+		// card name specific settings
+		
 		if (node.getAttributes().getNamedItem("value") != null)
 		{
 			value = node.getAttributes().getNamedItem("value").getNodeValue();
 		}
 		
+		if (node.getAttributes().getNamedItem("fontname") != null)
+		{
+			fontName = node.getAttributes().getNamedItem("fontname").getNodeValue();
+		}
+		
+		if (node.getAttributes().getNamedItem("fontstyle") != null)
+		{
+			fontStyle = Integer.parseInt(node.getAttributes().getNamedItem("fontstyle").getNodeValue());
+		}
+
+		if (node.getAttributes().getNamedItem("textsize") != null)
+		{
+			textSize = Integer.parseInt(node.getAttributes().getNamedItem("textsize").getNodeValue());
+		}
+		
+		
+		// sub name specific settings
+
 		if (node.getAttributes().getNamedItem("subnameValue") != null)
 		{
 			if (card.getTemplate() != null 
@@ -418,17 +455,17 @@ public class ElementCardName extends CustomElement implements Cloneable {
 				subnameValue = node.getAttributes().getNamedItem("subnameValue").getNodeValue();
 			}
 		}
-		
-		if (node.getAttributes().getNamedItem("fontname") != null)
+
+		if (node.getAttributes().getNamedItem("subnamefontname") != null)
 		{
-			fontName = node.getAttributes().getNamedItem("fontname").getNodeValue();
+			subnameFontName = node.getAttributes().getNamedItem("subnamefontname").getNodeValue();
 		}
 		
-		if (node.getAttributes().getNamedItem("textsize") != null)
+		if (node.getAttributes().getNamedItem("subnamefontstyle") != null)
 		{
-			textSize = Integer.parseInt(node.getAttributes().getNamedItem("textsize").getNodeValue());
+			subnameFontStyle = Integer.parseInt(node.getAttributes().getNamedItem("subnamefontstyle").getNodeValue());
 		}
-		
+
 		if (node.getAttributes().getNamedItem("subnamesize") != null)
 		{
 			subnameSize = Integer.parseInt(node.getAttributes().getNamedItem("subnamesize").getNodeValue());

--- a/src/legedit2/cardtype/ElementScrollingTextArea.java
+++ b/src/legedit2/cardtype/ElementScrollingTextArea.java
@@ -101,7 +101,7 @@ public class ElementScrollingTextArea extends CustomElement {
 	    	try
 	    	{
 	    		font = Font.createFont(Font.TRUETYPE_FONT, new File("legedit" + File.separator + "fonts" + File.separator + "Swiss 721 Light Condensed.ttf"));
-	    		font = font.deriveFont((float)getPercentage(textSize,getScale()));
+	    		font = font.deriveFont(fontStyle, (float)getPercentage(textSize,getScale()));
 	    		if (fontName != null)
 	    		{
 	    			font = new Font(fontName, fontStyle, getPercentage(textSize,getScale()));
@@ -735,6 +735,11 @@ public class ElementScrollingTextArea extends CustomElement {
 			fontNameBold = node.getAttributes().getNamedItem("fontnamebold").getNodeValue();
 		}
 		
+		if (node.getAttributes().getNamedItem("fontstyle") != null)
+		{
+			fontStyle = Integer.parseInt(node.getAttributes().getNamedItem("fontstyle").getNodeValue());
+		}
+
 		if (node.getAttributes().getNamedItem("textsize") != null)
 		{
 			textSize = Integer.parseInt(node.getAttributes().getNamedItem("textsize").getNodeValue());
@@ -752,8 +757,9 @@ public class ElementScrollingTextArea extends CustomElement {
 		String str = "";
 		
 		str += "<scrollingtextarea name=\"" + replaceNonXMLCharacters(name) + "\" value=\""+replaceNonXMLCharacters(getValue())+"\" "
-				+ (fontName == null ? " " : "fontname=\""+replaceNonXMLCharacters(fontName)+"\" ")
-				+ (fontNameBold == null ? " " : "fontnamebold=\""+replaceNonXMLCharacters(fontNameBold)+"\" ")
+				+ (fontName == null ? "" : "fontname=\""+replaceNonXMLCharacters(fontName)+"\" ")
+				+ (fontNameBold == null ? "" : "fontnamebold=\""+replaceNonXMLCharacters(fontNameBold)+"\" ")
+				+ ((fontName == null && fontNameBold == null) ? "" : "fontstyle=\""+fontStyle+"\" ")
 				+ "textsize=\""+textSize+"\" "
 				+ "textsizebold=\""+textSizeBold+"\" />\n";
 		

--- a/src/legedit2/cardtype/ElementText.java
+++ b/src/legedit2/cardtype/ElementText.java
@@ -11,6 +11,7 @@ import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 import java.io.File;
 
+import javax.swing.JButton;
 import javax.swing.JTextField;
 import javax.swing.SwingUtilities;
 
@@ -42,6 +43,7 @@ public class ElementText extends CustomElement {
 	public String value;
 	
 	private JTextField textField;
+	private JButton fontButton;
 	
 	public void drawElement(Graphics2D g)
 	{
@@ -60,7 +62,7 @@ public class ElementText extends CustomElement {
 	    	try
 	    	{
 	    	font = Font.createFont(Font.TRUETYPE_FONT, new File("legedit" + File.separator + "fonts" + File.separator + "Sylfaen.ttf"));
-	        font = font.deriveFont((float)getPercentage(textSize,getScale()));
+	        font = font.deriveFont(fontStyle, (float)getPercentage(textSize,getScale()));
 	    	}
 	    	catch (Exception e)
 	    	{
@@ -180,14 +182,37 @@ public class ElementText extends CustomElement {
 			value = node.getAttributes().getNamedItem("value").getNodeValue();
 			value = restoreNonXMLCharacters(value);
 		}
+		
+		if (node.getAttributes().getNamedItem("fontname") != null)
+		{
+			fontName = node.getAttributes().getNamedItem("fontname").getNodeValue();
+		}
+		
+		if (node.getAttributes().getNamedItem("fontstyle") != null)
+		{
+			fontStyle = Integer.parseInt(node.getAttributes().getNamedItem("fontstyle").getNodeValue());
+		}
+
+		if (node.getAttributes().getNamedItem("textsize") != null)
+		{
+			textSize = Integer.parseInt(node.getAttributes().getNamedItem("textsize").getNodeValue());
+		}
 	}
 	
 	public String getDifferenceXML()
 	{
 		String str = "";
 		
-		str += "<text name=\"" + replaceNonXMLCharacters(name) + "\" value=\""+replaceNonXMLCharacters(getValue())+"\" />\n";
+		str += "<text name=\"" + replaceNonXMLCharacters(name) + "\" value=\""+replaceNonXMLCharacters(getValue())+ "\" "
+				+ (fontName == null ? "" : "fontname=\""+replaceNonXMLCharacters(fontName) + "\" ")
+				+ (fontName == null ? "" : "fontstyle=\""+fontStyle+"\" ")
+				+ "textsize=\""+textSize+"\" />\n";
 		
+
 		return str;
 	}
+
+	public void setFontButton(JButton fontButton) {
+		this.fontButton = fontButton;
+	}	
 }

--- a/src/legedit2/cardtype/ElementTextArea.java
+++ b/src/legedit2/cardtype/ElementTextArea.java
@@ -882,6 +882,11 @@ public class ElementTextArea extends CustomElement {
 			fontNameBold = node.getAttributes().getNamedItem("fontnamebold").getNodeValue();
 		}
 		
+		if (node.getAttributes().getNamedItem("fontstyle") != null)
+		{
+			fontStyle = Integer.parseInt(node.getAttributes().getNamedItem("fontstyle").getNodeValue());
+		}
+		
 		if (node.getAttributes().getNamedItem("textsize") != null)
 		{
 			textSize = Integer.parseInt(node.getAttributes().getNamedItem("textsize").getNodeValue());
@@ -899,8 +904,9 @@ public class ElementTextArea extends CustomElement {
 		String str = "";
 		
 		str += "<textarea name=\"" + replaceNonXMLCharacters(name) + "\" value=\""+replaceNonXMLCharacters(getValue())+"\" "
-				+ (fontName == null ? " " : "fontname=\""+replaceNonXMLCharacters(fontName)+"\" ")
-				+ (fontNameBold == null ? " " : "fontnamebold=\""+replaceNonXMLCharacters(fontNameBold)+"\" ")
+				+ (fontName == null ? "" : "fontname=\""+replaceNonXMLCharacters(fontName)+"\" ")
+				+ (fontNameBold == null ? "" : "fontnamebold=\""+replaceNonXMLCharacters(fontNameBold)+"\" ")
+				+ (fontName == null ? "" : "fontstyle=\""+fontStyle+"\" ")
 				+ "textsize=\""+textSize+"\" "
 				+ "textsizebold=\""+textSizeBold+"\" />\n";
 		

--- a/src/legedit2/gui/editor/CardPropertyPanel.java
+++ b/src/legedit2/gui/editor/CardPropertyPanel.java
@@ -582,8 +582,11 @@ public class CardPropertyPanel extends JPanel implements ActionListener {
 					int showDialog = chooser.showDialog(LegeditFrame.legedit);
 					if (showDialog == JFontChooser.OK_OPTION)
 					{
-						el.textSize = chooser.getSelectedFont().getSize();
-						el.textSizeBold = chooser.getSelectedFont().getSize();
+						Font selectedFont = chooser.getSelectedFont();
+						el.fontName = selectedFont.getName();
+						el.textSize = selectedFont.getSize();
+						el.textSizeBold = selectedFont.getSize();
+						el.fontStyle = selectedFont.getStyle();
 					}
 				}
 			});

--- a/src/legedit2/gui/editor/CardPropertyPanel.java
+++ b/src/legedit2/gui/editor/CardPropertyPanel.java
@@ -920,7 +920,10 @@ public class CardPropertyPanel extends JPanel implements ActionListener {
 					int showDialog = chooser.showDialog(LegeditFrame.legedit);
 					if (showDialog == JFontChooser.OK_OPTION)
 					{
-						el.textSize = chooser.getSelectedFont().getSize();
+						Font selectedFont = chooser.getSelectedFont();
+						el.fontName = selectedFont.getName();
+						el.fontStyle = selectedFont.getStyle();
+						el.textSize = selectedFont.getSize();
 					}
 				}
 			});
@@ -942,9 +945,9 @@ public class CardPropertyPanel extends JPanel implements ActionListener {
 						font = Font.createFont(Font.TRUETYPE_FONT, new File("legedit" + File.separator + "fonts" + File.separator + "Percolator.otf"));
 						font = font.deriveFont((float)el.subnameSize);
 						
-						if (el.fontName != null)
+						if (el.subnameFontName != null)
 			    		{
-			    			font = new Font(el.fontName, el.fontStyle, el.subnameSize);
+			    			font = new Font(el.subnameFontName, el.subnameFontStyle, el.subnameSize);
 			    		}
 						
 						chooser.setFont(font);
@@ -957,7 +960,10 @@ public class CardPropertyPanel extends JPanel implements ActionListener {
 					int showDialog = chooser.showDialog(LegeditFrame.legedit);
 					if (showDialog == JFontChooser.OK_OPTION)
 					{
-						el.subnameSize = chooser.getSelectedFont().getSize();
+						Font selectedFont = chooser.getSelectedFont();
+						el.subnameFontName = selectedFont.getName();
+						el.subnameFontStyle = selectedFont.getStyle();
+						el.subnameSize = selectedFont.getSize();
 					}
 				}
 			});

--- a/src/legedit2/gui/editor/CardPropertyPanel.java
+++ b/src/legedit2/gui/editor/CardPropertyPanel.java
@@ -456,15 +456,56 @@ public class CardPropertyPanel extends JPanel implements ActionListener {
 			JTextField nameField = new JTextField();
 			c = new GridBagConstraints();
 			c.fill = GridBagConstraints.HORIZONTAL;
-			c.gridwidth = 3;
+			c.gridwidth = GridBagConstraints.RELATIVE;
 			c.gridx = 1;
 			c.gridy = row;
 			c.weightx = 0.5;
-			panel.add(nameField, c);
-			nameField.setText(el.getValue());
-			
+			nameField.setText(el.getValue());			
 			el.setTextField(nameField);
-			row++;
+			panel.add(nameField, c);
+			
+			JButton fontButton = new JButton("Font");
+			c = new GridBagConstraints();
+			c.fill = GridBagConstraints.HORIZONTAL;
+			c.gridwidth = 1;
+			c.gridx = 3;
+			c.gridy = row;			
+			fontButton.addActionListener(new ActionListener() {
+				@Override
+				public void actionPerformed(ActionEvent e) {
+					JFontChooser chooser = new JFontChooser();
+					
+					Font font;
+					try {
+						font = Font.createFont(Font.TRUETYPE_FONT, new File("legedit" + File.separator + "fonts" + File.separator + "Swiss 721 Light Condensed.ttf"));
+						font = font.deriveFont(el.fontStyle, (float)el.textSize);
+						
+						if (el.fontName != null)
+			    		{
+			    			font = new Font(el.fontName, el.fontStyle, el.textSize);
+			    		}
+						
+						chooser.setFont(font);
+						chooser.setSelectedFont(font);
+						
+					} catch (Exception e1) {
+						e1.printStackTrace();
+					}
+					
+					int showDialog = chooser.showDialog(LegeditFrame.legedit);
+					if (showDialog == JFontChooser.OK_OPTION)
+					{
+						Font selectedFont = chooser.getSelectedFont();
+						el.fontName = selectedFont.getName();
+						el.textSize = selectedFont.getSize();
+						el.fontStyle = selectedFont.getStyle();
+					}
+				}
+			});
+			panel.add(fontButton, c);			
+			el.setFontButton(fontButton);
+			
+			row++;			
 		}
 		
 		return row;

--- a/src/legedit2/gui/editor/CardPropertyPanel.java
+++ b/src/legedit2/gui/editor/CardPropertyPanel.java
@@ -752,7 +752,7 @@ public class CardPropertyPanel extends JPanel implements ActionListener {
 					Font font;
 					try {
 						font = Font.createFont(Font.TRUETYPE_FONT, new File("legedit" + File.separator + "fonts" + File.separator + "Swiss 721 Light Condensed.ttf"));
-						font = font.deriveFont((float)el.textSize);
+						font = font.deriveFont(el.fontStyle, (float)el.textSize);
 						
 						if (el.fontName != null)
 			    		{
@@ -769,8 +769,11 @@ public class CardPropertyPanel extends JPanel implements ActionListener {
 					int showDialog = chooser.showDialog(LegeditFrame.legedit);
 					if (showDialog == JFontChooser.OK_OPTION)
 					{
-						el.textSize = chooser.getSelectedFont().getSize();
-						el.textSizeBold = chooser.getSelectedFont().getSize();
+						Font selectedFont = chooser.getSelectedFont();
+						el.textSize = selectedFont.getSize();
+						el.textSizeBold = selectedFont.getSize();
+						el.fontName = selectedFont.getName();
+						el.fontStyle = selectedFont.getStyle();
 					}
 				}
 			});


### PR DESCRIPTION
This change enhances the font support for CardName and Subname, ElementTextAreas, ElementText and ElementScrollingTextArea. Now all of these types will use the font name, style and size properly and will save them into the project file. Font style can be set through templates and added a first attempt for flavor text to Hero cards.