### PR TITLE
Fix for #20 Control for how much space a line break takes

### DIFF
--- a/legedit/cardtypes/hero_common/template.xml
+++ b/legedit/cardtypes/hero_common/template.xml
@@ -366,7 +366,9 @@
  rectxarray="140,660,660,555,555,140"
  rectyarray="780,780,880,880,965,1000"
  debug="false"
- />
+ spacebetweenlines="0.2"
+ spacebetweenparagraphs="0.2"
+/>
  
 <scrollingtextarea
  name="Flavor Text"

--- a/legedit/cardtypes/hero_common_transformed/template.xml
+++ b/legedit/cardtypes/hero_common_transformed/template.xml
@@ -368,7 +368,9 @@
  rectxarray="140,660,660,555,555,140"
  rectyarray="780,780,880,880,965,1000"
  debug="false"
- />
+ spacebetweenlines="0.2"
+ spacebetweenparagraphs="0.2"
+/>
  
 <scrollingtextarea
  name="Flavor Text"

--- a/legedit/cardtypes/hero_rare/template.xml
+++ b/legedit/cardtypes/hero_rare/template.xml
@@ -337,7 +337,9 @@
  rectxarray="140,670,670,555,555,140"
  rectyarray="780,780,880,880,1010,1010"
  debug="false"
- />
+ spacebetweenlines="0.2"
+ spacebetweenparagraphs="0.2"
+/>
  
 <scrollingtextarea
  name="Flavor Text"

--- a/legedit/cardtypes/hero_rare_transformed/template.xml
+++ b/legedit/cardtypes/hero_rare_transformed/template.xml
@@ -339,7 +339,9 @@
  rectxarray="140,670,670,555,555,140"
  rectyarray="780,780,880,880,1010,1010"
  debug="false"
- />
+ spacebetweenlines="0.2"
+ spacebetweenparagraphs="0.2"
+/>
 
 <scrollingtextarea
  name="Flavor Text"

--- a/legedit/cardtypes/hero_uncommon/template.xml
+++ b/legedit/cardtypes/hero_uncommon/template.xml
@@ -366,7 +366,9 @@
  rectxarray="140,740,740,555,555,140"
  rectyarray="780,780,880,880,965,1000"
  debug="false"
- />
+ spacebetweenlines="0.2"
+ spacebetweenparagraphs="0.2"
+/>
 
 <scrollingtextarea
  name="Flavor Text"

--- a/legedit/cardtypes/hero_uncommon_transformed/template.xml
+++ b/legedit/cardtypes/hero_uncommon_transformed/template.xml
@@ -368,7 +368,9 @@
  rectxarray="140,740,740,555,555,140"
  rectyarray="780,780,880,880,965,1000"
  debug="false"
- />
+ spacebetweenlines="0.2"
+ spacebetweenparagraphs="0.2"
+/>
 
 <scrollingtextarea
  name="Flavor Text"

--- a/legedit/cardtypes/scheme/template.xml
+++ b/legedit/cardtypes/scheme/template.xml
@@ -124,7 +124,9 @@
  imagemaxheight="1050"
  imageallowchange="false"
  imagezoomable="false"
- />
+ spacebetweenlines="0.2"
+ spacebetweenparagraphs="0.2"
+/>
 
 <property
  name="Number in Deck"

--- a/src/legedit2/cardtype/CardType.java
+++ b/src/legedit2/cardtype/CardType.java
@@ -968,6 +968,16 @@ public class CardType extends ItemType implements Cloneable {
 				element.rotate = Integer.parseInt(node.getAttributes().getNamedItem("rotate").getNodeValue());
 			}
 			
+			if (node.getAttributes().getNamedItem("spacebetweenlines") != null)
+			{
+				element.gapSizeBetweenLines = Double.parseDouble(node.getAttributes().getNamedItem("spacebetweenlines").getNodeValue());
+			}
+
+			if (node.getAttributes().getNamedItem("spacebetweenparagraphs") != null)
+			{
+				element.gapSizeBetweenParagraphs = Double.parseDouble(node.getAttributes().getNamedItem("spacebetweenparagraphs").getNodeValue());
+			}
+
 			t.addElement(element, s, group);
 		}
 		
@@ -1081,6 +1091,17 @@ public class CardType extends ItemType implements Cloneable {
 			{
 				element.headerColour = Color.decode(node.getAttributes().getNamedItem("headercolour").getNodeValue());
 			}
+			
+			if (node.getAttributes().getNamedItem("spacebetweenlines") != null)
+			{
+				element.gapSizeBetweenLines = Double.parseDouble(node.getAttributes().getNamedItem("spacebetweenlines").getNodeValue());
+			}
+
+			if (node.getAttributes().getNamedItem("spacebetweenparagraphs") != null)
+			{
+				element.gapSizeBetweenParagraphs = Double.parseDouble(node.getAttributes().getNamedItem("spacebetweenparagraphs").getNodeValue());
+			}
+			
 
 			/* Attach a BG image */
 			ElementBackgroundImage bg = new ElementBackgroundImage();

--- a/src/legedit2/cardtype/ElementScrollingTextArea.java
+++ b/src/legedit2/cardtype/ElementScrollingTextArea.java
@@ -25,38 +25,41 @@ import legedit2.imaging.GaussianFilter;
 
 public class ElementScrollingTextArea extends CustomElement {
 	
+	//////////////////////////////////////////////////////////////////
+	/// Editable through template data
+	//////////////////////////////////////////////////////////////////
 	public String defaultValue;
-	public ALIGNMENT alignmentHorizontal = ALIGNMENT.LEFT;
-	public ALIGNMENT alignmentVertical = ALIGNMENT.TOP;
 	public boolean allowChange;
 	public Color colour;
-	public int textSize = 27;
-	public int textSizeBold = 27;
-	public int textSizeHeader = 45;
 	public String fontName;
 	public String fontNameBold;
-	public String fontNameHeader;
 	public int fontStyle;
-	public String headerText;
-	public Color headerColour = Color.red;
-
+	public int textSize = 27;
+	public int textSizeBold = 27;
+	public ALIGNMENT alignmentHorizontal = ALIGNMENT.LEFT;
+	public ALIGNMENT alignmentVertical = ALIGNMENT.TOP;
 	public int startX = 0;
 	public int endX = 750;
 	public int startY = 50;
 	public int endY = 1050;
-	
 	public String direction = "up";
-	
 	public boolean debug = false;
+	public double gapSizeBetweenLines = 0.2d;
+	public double gapSizeBetweenParagraphs = 0.6d;
+	//////////////////////////////////////////////////////////////////
+
+	//////////////////////////////////////////////////////////////////
+	/// Editable through save file
+	//////////////////////////////////////////////////////////////////
+	public String value;
+	//////////////////////////////////////////////////////////////////
 	
-	public double textGapHeight = 0.6d;
-	public double textDefaultGapHeight = 0.2d;
+	public int textSizeHeader = 45;
+	public String headerText;
+	public Color headerColour = Color.red;
 	public int textIconBlurRadius = 5;
 	public boolean textIconBlurDouble = true;
 	public int expandTextIcon = 0;
-
-	
-	public String value;
 	
 	private JTextArea textArea;
 	private JScrollPane scrollPane;
@@ -293,7 +296,7 @@ public class ElementScrollingTextArea extends CustomElement {
 			    			Icon icon = isIcon(s);
 			    			if (gap == true)
 			    			{
-			    				y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textGapHeight);
+			    				y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenParagraphs);
 			    				x = getPercentage(startX, getScale());
 			    			}
 			    			else if (icon == null)
@@ -309,7 +312,7 @@ public class ElementScrollingTextArea extends CustomElement {
 			    						xEnd = x;
 			    					}
 			    					*/
-			    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textDefaultGapHeight);
+			    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenLines);
 			    					x = getPercentage(startX, getScale());
 			    				}
 			    				g2.drawString(s + " ", x, y);
@@ -328,7 +331,7 @@ public class ElementScrollingTextArea extends CustomElement {
 			    						xEnd = x;
 			    					}
 			    					*/
-			    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textDefaultGapHeight);
+			    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenLines);
 			    					x = getPercentage(startX, getScale());
 			    				}
 			    				
@@ -385,9 +388,9 @@ public class ElementScrollingTextArea extends CustomElement {
 	    	if (direction.equalsIgnoreCase("up"))
 			{
 				directionY = getPercentage(endY, getScale()) - (y - getPercentage(startY, getScale()))
-					- g2.getFontMetrics(font).getHeight() - getPercentage(g2.getFontMetrics(font).getHeight(), textGapHeight)
-						- g2.getFontMetrics(font).getHeight() - getPercentage(g2.getFontMetrics(font).getHeight(), textGapHeight)
-						- g2.getFontMetrics(font).getHeight() - getPercentage(g2.getFontMetrics(font).getHeight(), textGapHeight);
+					- g2.getFontMetrics(font).getHeight() - getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenParagraphs)
+						- g2.getFontMetrics(font).getHeight() - getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenParagraphs)
+						- g2.getFontMetrics(font).getHeight() - getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenParagraphs);
 			}
 			else
 			{

--- a/src/legedit2/cardtype/ElementTextArea.java
+++ b/src/legedit2/cardtype/ElementTextArea.java
@@ -29,32 +29,38 @@ import legedit2.imaging.GaussianFilter;
 
 public class ElementTextArea extends CustomElement {
 	
+	//////////////////////////////////////////////////////////////////
+	/// Editable through template data
+	//////////////////////////////////////////////////////////////////
 	public String defaultValue;
-	public ALIGNMENT alignmentHorizontal = ALIGNMENT.LEFT;
-	public ALIGNMENT alignmentVertical = ALIGNMENT.TOP;
 	public boolean allowChange;
 	public Color colour;
-	public int textSize = 27;
-	public int textSizeBold = 27;
-	public int textSizeHeader = 45;
 	public String fontName;
 	public String fontNameBold;
-	public String fontNameHeader;
-	public int fontStyle;
+	public int textSize = 27;
+	public int textSizeBold = 27;
+	public ALIGNMENT alignmentHorizontal = ALIGNMENT.LEFT;
+	public ALIGNMENT alignmentVertical = ALIGNMENT.TOP;
 	public String rectXArray;
 	public String rectYArray;
 	public boolean debug = false;
-	
-	public double textGapHeight = 0.6d;
-	public double textDefaultGapHeight = 0.2d;
+	public double gapSizeBetweenLines = 0.2d;
+	public double gapSizeBetweenParagraphs = 0.6d;
+	//////////////////////////////////////////////////////////////////
+
+	//////////////////////////////////////////////////////////////////
+	/// Editable through save file
+	//////////////////////////////////////////////////////////////////
+	public String value;
+	public int fontStyle;	
+	//////////////////////////////////////////////////////////////////
+
+	public int textSizeHeader = 45;
 	public int textIconBlurRadius = 5;
 	public boolean textIconBlurDouble = true;
 	public int expandTextIcon = 0;
 	
 	private Polygon polygon = null;
-	
-	public String value;
-	
 	private JTextArea textArea;
 	private JScrollPane scrollPane;
 	private JComboBox<Icon> iconComboBox;
@@ -244,7 +250,7 @@ public class ElementTextArea extends CustomElement {
 			    			Icon icon = isIcon(s);
 			    			if (gap == true)
 			    			{
-			    				y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textGapHeight);
+			    				y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenParagraphs);
 			    				x = getXStart(y);
 			    			}
 			    			else if (icon == null)
@@ -260,7 +266,7 @@ public class ElementTextArea extends CustomElement {
 			    						xEnd = x;
 			    					}
 			    					*/
-			    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textDefaultGapHeight);
+			    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenLines);
 			    					x = getXStart(y);
 			    				}
 			    				g2.drawString(s + " ", x, y);
@@ -279,7 +285,7 @@ public class ElementTextArea extends CustomElement {
 			    						xEnd = x;
 			    					}
 			    					*/
-			    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textDefaultGapHeight);
+			    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenLines);
 			    					x = getXStart(y);
 			    				}
 			    				
@@ -427,7 +433,7 @@ public class ElementTextArea extends CustomElement {
 	    			Icon icon = isIcon(s);
 	    			if (gap == true)
 	    			{
-	    				y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textGapHeight);
+	    				y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenParagraphs);
 	    				x = getXStart(y);
 	    			}
 	    			else if (icon == null)
@@ -443,7 +449,7 @@ public class ElementTextArea extends CustomElement {
 	    						xEnd = x;
 	    					}
 	    					*/
-	    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textDefaultGapHeight);
+	    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenLines);
 	    					x = getXStart(y);
 	    				}
 	    				g2.drawString(s + " ", x, y);
@@ -462,7 +468,7 @@ public class ElementTextArea extends CustomElement {
 	    						xEnd = x;
 	    					}
 	    					*/
-	    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), textDefaultGapHeight);
+	    					y += g2.getFontMetrics(font).getHeight() + getPercentage(g2.getFontMetrics(font).getHeight(), gapSizeBetweenLines);
 	    					x = getXStart(y);
 	    				}
 	    				


### PR DESCRIPTION
Added some properties to Text Areas and Scrolling Text Area to control the space between lines and when entering a manual line break.
Since the code by default uses a value of 0.6 for manual line breaks, I left it like that and instead modified the Heroes and Scheme templates to set that value to 0.2 instead (which is the value used for between lines).
This way anyone can tweak them if they like. XML properties are called spacebetweenlines and spacebetweenparagraphs.