### PR TITLE
Fix for #9 LegEdit2 only uses the last read card width/height for all cards

### DIFF
--- a/src/legedit2/cardtype/CardType.java
+++ b/src/legedit2/cardtype/CardType.java
@@ -234,19 +234,16 @@ public class CardType extends ItemType implements Cloneable {
 		{
 			if (node.getAttributes().getNamedItem("cardwidth") != null)
 			{
-				//CustomCardMaker.cardWidth = Integer.parseInt(node.getAttributes().getNamedItem("cardwidth").getNodeValue());
 				t.setCardWidth(Integer.parseInt(node.getAttributes().getNamedItem("cardwidth").getNodeValue()));
 			}
 			
 			if (node.getAttributes().getNamedItem("cardheight") != null)
 			{
-				//CustomCardMaker.cardHeight = Integer.parseInt(node.getAttributes().getNamedItem("cardheight").getNodeValue());
 				t.setCardHeight(Integer.parseInt(node.getAttributes().getNamedItem("cardheight").getNodeValue()));
 			}
 			
 			if (node.getAttributes().getNamedItem("dpi") != null)
 			{
-				//CustomCardMaker.dpi = Integer.parseInt(node.getAttributes().getNamedItem("dpi").getNodeValue());
 				t.setCardDpi(Integer.parseInt(node.getAttributes().getNamedItem("dpi").getNodeValue()));
 			}
 		}

--- a/src/legedit2/cardtype/CardType.java
+++ b/src/legedit2/cardtype/CardType.java
@@ -39,6 +39,11 @@ public class CardType extends ItemType implements Cloneable {
 	
 	private Style style;
 	
+	// 2.5 by 3.5 inches - Poker Size
+	private int cardWidth = 750;
+	private int cardHeight = 1050;
+	private int cardDpi = 300;	
+	
 	public String getName()
 	{
 		return templateName;
@@ -229,17 +234,20 @@ public class CardType extends ItemType implements Cloneable {
 		{
 			if (node.getAttributes().getNamedItem("cardwidth") != null)
 			{
-				CustomCardMaker.cardWidth = Integer.parseInt(node.getAttributes().getNamedItem("cardwidth").getNodeValue());
+				//CustomCardMaker.cardWidth = Integer.parseInt(node.getAttributes().getNamedItem("cardwidth").getNodeValue());
+				t.setCardWidth(Integer.parseInt(node.getAttributes().getNamedItem("cardwidth").getNodeValue()));
 			}
 			
 			if (node.getAttributes().getNamedItem("cardheight") != null)
 			{
-				CustomCardMaker.cardHeight = Integer.parseInt(node.getAttributes().getNamedItem("cardheight").getNodeValue());
+				//CustomCardMaker.cardHeight = Integer.parseInt(node.getAttributes().getNamedItem("cardheight").getNodeValue());
+				t.setCardHeight(Integer.parseInt(node.getAttributes().getNamedItem("cardheight").getNodeValue()));
 			}
 			
 			if (node.getAttributes().getNamedItem("dpi") != null)
 			{
-				CustomCardMaker.dpi = Integer.parseInt(node.getAttributes().getNamedItem("dpi").getNodeValue());
+				//CustomCardMaker.dpi = Integer.parseInt(node.getAttributes().getNamedItem("dpi").getNodeValue());
+				t.setCardDpi(Integer.parseInt(node.getAttributes().getNamedItem("dpi").getNodeValue()));
 			}
 		}
 		
@@ -1295,6 +1303,30 @@ public class CardType extends ItemType implements Cloneable {
 		this.templateName = templateName;
 	}
 	
+	public void setCardWidth(int width){
+		this.cardWidth = width;
+	}
+
+	public void setCardHeight(int height){
+		this.cardHeight = height;
+	}
+
+	public void setCardDpi(int dpi){
+		this.cardDpi = dpi;
+	}
+	
+	public int getCardWidth(){
+		return this.cardWidth;
+	}
+	
+	public int getCardHeight(){
+		return this.cardHeight;
+	}
+
+	public int getCardDpi(){
+		return this.cardDpi;
+	}
+
 	public static Card generateLegeditItem(CardType type)
 	{
 		Card cc = new Card();

--- a/src/legedit2/cardtype/CustomElement.java
+++ b/src/legedit2/cardtype/CustomElement.java
@@ -166,7 +166,7 @@ public class CustomElement implements Cloneable {
 	
 	public void drawUnderlay(BufferedImage bi, Graphics g, int type, int x, int y, int blurRadius, boolean doubleBlur, int expandBlackout, Color underlayColour)
 	{
-		BufferedImage blackout = new BufferedImage(CustomCardMaker.cardWidth, CustomCardMaker.cardHeight, type);
+		BufferedImage blackout = new BufferedImage(template.getCardWidth(), template.getCardHeight(), type);
     	getGraphics(blackout).drawImage(bi, x, y, null);
     	
     	blackout = blackoutImage(blackout, underlayColour);
@@ -207,7 +207,7 @@ public class CustomElement implements Cloneable {
 	
 	public BufferedImage expandBlackout(BufferedImage image, int expandBlackout, Color blackoutColor)
 	{
-		BufferedImage expand = new BufferedImage(CustomCardMaker.cardWidth, CustomCardMaker.cardHeight, BufferedImage.TYPE_INT_ARGB);
+		BufferedImage expand = new BufferedImage(template.getCardWidth(), template.getCardHeight(), BufferedImage.TYPE_INT_ARGB);
 		
 		int width = image.getWidth();
         int height = image.getHeight();

--- a/src/legedit2/cardtype/ElementBackgroundImage.java
+++ b/src/legedit2/cardtype/ElementBackgroundImage.java
@@ -63,7 +63,7 @@ public class ElementBackgroundImage extends CustomElement {
 				BufferedImage bi = null;
 				if (fullSize)
 				{
-					bi = resizeImage(new ImageIcon(file), getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()));				
+					bi = resizeImage(new ImageIcon(file), getPercentage(template.getCardWidth(), getScale()), getPercentage(template.getCardHeight(), getScale()));				
 				}
 				else
 				{

--- a/src/legedit2/cardtype/ElementCardName.java
+++ b/src/legedit2/cardtype/ElementCardName.java
@@ -19,7 +19,6 @@ import javax.swing.SwingUtilities;
 import org.w3c.dom.Node;
 
 import legedit2.card.Card;
-import legedit2.imaging.CustomCardMaker;
 import legedit2.imaging.MotionBlurOp;
 
 
@@ -170,9 +169,11 @@ public class ElementCardName extends CustomElement implements Cloneable {
         	double scale = getScale();
         	int xScaled = getPercentage(x, scale);
 	        int currentY = getPercentage(y, scale);
-
 	        
-	        BufferedImage bi = new BufferedImage(getPercentage(CustomCardMaker.cardWidth, getScale()), getPercentage(CustomCardMaker.cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
+	        int cardWidth = template.getCardWidth();
+	        int cardHeight = template.getCardHeight();
+	        
+	        BufferedImage bi = new BufferedImage(getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
 			Graphics2D g2 = getGraphics(bi);
 			g2 = setGraphicsHints(g2);
 			
@@ -248,8 +249,8 @@ public class ElementCardName extends CustomElement implements Cloneable {
 	        
 	        if (highlight.equals(HIGHLIGHT.BANNER) || highlight.equals(HIGHLIGHT.BANNER_BLUR))
 	        {	        
-	        	int cardWidthScaled = getPercentage(CustomCardMaker.cardWidth, getScale());
-	        	int cardHeightScaled = getPercentage(CustomCardMaker.cardHeight, getScale());
+	        	int cardWidthScaled = getPercentage(cardWidth, getScale());
+	        	int cardHeightScaled = getPercentage(cardHeight, getScale());
 
 	        	int bannerStart = 0;
 	        	LineInformation firstLine = null;

--- a/src/legedit2/cardtype/ElementIconImage.java
+++ b/src/legedit2/cardtype/ElementIconImage.java
@@ -59,15 +59,18 @@ public class ElementIconImage extends CustomElement {
 		
 		
 		if (file != null && new File(file).exists())
-		{	
+		{
+			int cardWidth = template.getCardWidth();
+			int cardHeight = template.getCardHeight();
+			
 			BufferedImage bi = null;
 			if (imageFilter == null)
 			{
-				bi = resizeImage(new ImageIcon(file), getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight, getScale()));
+				bi = resizeImage(new ImageIcon(file), getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()));
 			}
 			if (imageFilter != null && imageFilter.equalsIgnoreCase("dualclass") && !getIconValue().getEnumName().equals("NONE"))
 			{
-				bi = resizeImage(new ImageIcon(getFadedBackground(new ImageIcon(file))), getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight, getScale()));
+				bi = resizeImage(new ImageIcon(getFadedBackground(new ImageIcon(file))), getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()));
 			}
 			
 			if (rotate > 0)
@@ -181,14 +184,17 @@ public class ElementIconImage extends CustomElement {
 	
 	private BufferedImage getFadedBackground(ImageIcon ii)
 	{
-		BufferedImage bi = new BufferedImage(CustomCardMaker.cardWidth, CustomCardMaker.cardHeight, BufferedImage.TYPE_INT_ARGB);
+		int cardWidth = template.getCardWidth();
+		int cardHeight = template.getCardHeight();
+
+		BufferedImage bi = new BufferedImage(cardWidth, cardHeight, BufferedImage.TYPE_INT_ARGB);
 		Graphics g = bi.getGraphics();
-		g.drawImage(ii.getImage(), 0, 0, CustomCardMaker.cardWidth, CustomCardMaker.cardHeight, null);
+		g.drawImage(ii.getImage(), 0, 0, cardWidth, cardHeight, null);
 		
 		int width = bi.getWidth();
 		int height = bi.getHeight();
 		
-		int fadeHeight = getPercentage(CustomCardMaker.cardHeight, 0.14d);
+		int fadeHeight = getPercentage(cardHeight, 0.14d);
 		double increment = 255d / (double)fadeHeight;
 		
 //		int alpha = 0;
@@ -197,10 +203,10 @@ public class ElementIconImage extends CustomElement {
 //                Color originalColor = new Color(bi.getRGB(xx, yy), true);
 //                if (originalColor.getAlpha() > 0) {
 //                	
-//                	if (yy <= ((CustomCardMaker.cardHeight / 2) + (fadeHeight / 2)))
+//                	if (yy <= ((cardHeight / 2) + (fadeHeight / 2)))
 //                    {
 //                		
-//                    	alpha = (int)((((CustomCardMaker.cardHeight / 2) + (fadeHeight / 2)) - yy) * increment);
+//                    	alpha = (int)((((cardHeight / 2) + (fadeHeight / 2)) - yy) * increment);
 //                    	if (alpha > 255)
 //                    	{
 //                    		alpha = 255;
@@ -226,10 +232,10 @@ public class ElementIconImage extends CustomElement {
                 Color originalColor = new Color(bi.getRGB(xx, yy), true);
                 if (originalColor.getAlpha() > 0) {
                 	
-                	if (yy >= ((CustomCardMaker.cardHeight / 2) - (fadeHeight / 2)))
+                	if (yy >= ((cardHeight / 2) - (fadeHeight / 2)))
                     {
                 		
-                    	alpha = (int)((((CustomCardMaker.cardHeight / 2) + (fadeHeight / 2)) - yyn) * increment);
+                    	alpha = (int)((((cardHeight / 2) + (fadeHeight / 2)) - yyn) * increment);
                     	if (alpha > 255)
                     	{
                     		alpha = 255;

--- a/src/legedit2/cardtype/ElementImage.java
+++ b/src/legedit2/cardtype/ElementImage.java
@@ -57,7 +57,7 @@ public class ElementImage extends CustomElement {
 			BufferedImage bi = null;
 			if (fullSize)
 			{
-				bi = resizeImage(new ImageIcon(file), getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight, getScale()));
+				bi = resizeImage(new ImageIcon(file), getPercentage(template.getCardWidth(), getScale()), getPercentage(template.getCardHeight(), getScale()));
 			}
 			else
 			{

--- a/src/legedit2/cardtype/ElementScrollingTextArea.java
+++ b/src/legedit2/cardtype/ElementScrollingTextArea.java
@@ -84,14 +84,17 @@ public class ElementScrollingTextArea extends CustomElement {
 	{
 		if (getValue() != null)
 		{
-			BufferedImage bi = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
+			int cardWidth = template.getCardWidth();
+			int cardHeight = template.getCardHeight();
+			
+			BufferedImage bi = new BufferedImage(getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
 			Graphics2D g2 = getGraphics(bi);
 			g2 = setGraphicsHints(g2);
 			
 			if (debug)
 			{
 				g2.setColor(Color.BLACK);
-				g2.fillRect(getPercentage(startX, getScale()), getPercentage(startY, getScale()), getPercentage(endX - startX, getScale()), getPercentage(CustomCardMaker.cardHeight, getScale()));
+				g2.fillRect(getPercentage(startX, getScale()), getPercentage(startY, getScale()), getPercentage(endX - startX, getScale()), getPercentage(cardHeight, getScale()));
 			}
 			
 	    	g2.setColor(colour);
@@ -173,7 +176,7 @@ public class ElementScrollingTextArea extends CustomElement {
 					if (headerText != null && !headerText.isEmpty())
 					{
 						int headerHeight = (int)((double)g.getFontMetrics(fontHeader).getHeight() * 1.3d);
-						drawHeader(g2, headerText.toUpperCase(), fontHeader, headerColour, y - (headerHeight*2) + (int)(headerHeight*0.1d), headerHeight, getPercentage(CustomCardMaker.cardWidth, 0.2d), headerIcon);
+						drawHeader(g2, headerText.toUpperCase(), fontHeader, headerColour, y - (headerHeight*2) + (int)(headerHeight*0.1d), headerHeight, getPercentage(cardWidth, 0.2d), headerIcon);
 					}
 				}
 	    		
@@ -247,7 +250,7 @@ public class ElementScrollingTextArea extends CustomElement {
 		    				{
 		    					y -= lastWordBreakHeight;
 		    				}
-			    			drawHeader(g2, headerStr.toUpperCase(), fontHeader, /*card.cardType.getBgColor()*/ Color.red, y, headerHeight, getPercentage(CustomCardMaker.cardWidth, 0.2d), headerIcon);
+			    			drawHeader(g2, headerStr.toUpperCase(), fontHeader, /*card.cardType.getBgColor()*/ Color.red, y, headerHeight, getPercentage(cardWidth, 0.2d), headerIcon);
 				    		y += headerHeight + metrics.getHeight() + getPercentage(metrics.getHeight(), 0.5d);
 		    			}
 //		    			else
@@ -420,7 +423,7 @@ public class ElementScrollingTextArea extends CustomElement {
 						BufferedImage bi2 = null;
 						if (bg.fullSize)
 						{
-							bi2 = resizeImage(new ImageIcon(file), getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()));
+							bi2 = resizeImage(new ImageIcon(file), getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()));
 						}
 						else
 						{
@@ -537,11 +540,14 @@ public class ElementScrollingTextArea extends CustomElement {
 	
 	private void drawHeader(Graphics2D g, String header, Font font, Color color, int y, int height, int blurRadius, HeaderIcon headerIcon)
 	{
-		BufferedImage bi1 = new BufferedImage(getPercentage(CustomCardMaker.cardWidth, getScale()), getPercentage(CustomCardMaker.cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
+		int cardWidth = template.getCardWidth();
+		int cardHeight = template.getCardHeight();
+
+		BufferedImage bi1 = new BufferedImage(getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g2 = getGraphics(bi1);
 		
 		g2.setColor(color);
-		g2.fillRect(0, y, getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.8d), height);
+		g2.fillRect(0, y, getPercentage(getPercentage(cardWidth,getScale()), 0.8d), height);
     	
     	if (blurRadius > 0)
     	{
@@ -557,13 +563,13 @@ public class ElementScrollingTextArea extends CustomElement {
     	if (headerIcon != null && headerIcon.icon != null)
 	    {
 	    	BufferedImage bi = getIcon(headerIcon.icon, getPercentage(height, 1.9d), getPercentage(height, 1.9d));
-	    	int iconx = getPercentage(CustomCardMaker.cardWidth,getScale()) - getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.09d) - bi.getWidth() + (bi.getWidth() / 2);
+	    	int iconx = getPercentage(cardWidth, getScale()) - getPercentage(getPercentage(cardWidth,getScale()), 0.09d) - bi.getWidth() + (bi.getWidth() / 2);
 	    	int icony = y + (height / 2) - (bi.getWidth() / 2);
 	    	
 	    	g2.drawImage(bi, iconx, icony, null);
 	    }
     	
-    	BufferedImage bi2 = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
+    	BufferedImage bi2 = new BufferedImage(getPercentage(cardWidth,getScale()), getPercentage(cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g3 = getGraphics(bi2);	
 		
     	g3.setColor(Color.WHITE);
@@ -571,7 +577,7 @@ public class ElementScrollingTextArea extends CustomElement {
     	
     	g3 = setGraphicsHints(g3);
     	
-		g3.drawString(header, getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.04d), y + g.getFontMetrics(font).getHeight() - (g.getFontMetrics(font).getHeight() / 6));
+		g3.drawString(header, getPercentage(getPercentage(cardWidth,getScale()), 0.04d), y + g.getFontMetrics(font).getHeight() - (g.getFontMetrics(font).getHeight() / 6));
 		
 		if (headerIcon != null && headerIcon.value != null)
 		{
@@ -583,7 +589,7 @@ public class ElementScrollingTextArea extends CustomElement {
 			g3 = setGraphicsHints(g3);
 			
 			int stringLength = SwingUtilities.computeStringWidth(g.getFontMetrics(font), headerIcon.value.toUpperCase());
-			g3.drawString(headerIcon.value, getPercentage(CustomCardMaker.cardWidth,getScale()) - getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.09d) - stringLength + (stringLength / 2), y + g.getFontMetrics(font).getHeight() - (int)(g.getFontMetrics(font).getHeight() / 2.6d));
+			g3.drawString(headerIcon.value, getPercentage(cardWidth,getScale()) - getPercentage(getPercentage(cardWidth,getScale()), 0.09d) - stringLength + (stringLength / 2), y + g.getFontMetrics(font).getHeight() - (int)(g.getFontMetrics(font).getHeight() / 2.6d));
 			
 			font = originalFont;
 			g3.setFont(originalFont);
@@ -593,7 +599,7 @@ public class ElementScrollingTextArea extends CustomElement {
 		
 		drawUnderlay(bi2, g3, BufferedImage.TYPE_INT_ARGB, 0, 0, 7, false, 2);
 		
-		g3.drawString(header, getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.04d), y + g.getFontMetrics(font).getHeight() - (g.getFontMetrics(font).getHeight() / 6));
+		g3.drawString(header, getPercentage(getPercentage(cardWidth,getScale()), 0.04d), y + g.getFontMetrics(font).getHeight() - (g.getFontMetrics(font).getHeight() / 6));
 		
 		if (headerIcon != null && headerIcon.value != null)
 		{
@@ -603,7 +609,7 @@ public class ElementScrollingTextArea extends CustomElement {
 			g3.setFont(font);
 			g3 = setGraphicsHints(g3);
 			int stringLength = SwingUtilities.computeStringWidth(g.getFontMetrics(font), headerIcon.value.toUpperCase());
-			g3.drawString(headerIcon.value, getPercentage(CustomCardMaker.cardWidth,getScale()) - getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.09d) - stringLength + (stringLength / 2), y + g.getFontMetrics(font).getHeight() - (int)(g.getFontMetrics(font).getHeight() / 2.6d));
+			g3.drawString(headerIcon.value, getPercentage(cardWidth,getScale()) - getPercentage(getPercentage(cardWidth,getScale()), 0.09d) - stringLength + (stringLength / 2), y + g.getFontMetrics(font).getHeight() - (int)(g.getFontMetrics(font).getHeight() / 2.6d));
 			
 			font = originalFont;
 			g3.setFont(originalFont);
@@ -619,7 +625,7 @@ public class ElementScrollingTextArea extends CustomElement {
 	
 	private void drawUnderlay(BufferedImage bi, Graphics2D g, int type, int x, int y, int blurRadius, boolean doubleBlur, int expandBlackout)
 	{
-		BufferedImage blackout = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), type);
+		BufferedImage blackout = new BufferedImage(getPercentage(template.getCardWidth(), getScale()), getPercentage(template.getCardHeight(), getScale()), type);
     	getGraphics(blackout).drawImage(bi, x, y, null);
     	
     	blackout = blackoutImage(blackout);
@@ -665,7 +671,7 @@ public class ElementScrollingTextArea extends CustomElement {
 	
 	private BufferedImage expandBlackout(BufferedImage image, int expandBlackout)
 	{
-		BufferedImage expand = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
+		BufferedImage expand = new BufferedImage(getPercentage(template.getCardWidth(), getScale()), getPercentage(template.getCardHeight(), getScale()), BufferedImage.TYPE_INT_ARGB);
 		
 		int width = image.getWidth();
         int height = image.getHeight();

--- a/src/legedit2/cardtype/ElementText.java
+++ b/src/legedit2/cardtype/ElementText.java
@@ -49,7 +49,7 @@ public class ElementText extends CustomElement {
 	{
 		if (getValue() != null && visible == true)
 		{
-			BufferedImage bi = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
+			BufferedImage bi = new BufferedImage(getPercentage(template.getCardWidth(), getScale()), getPercentage(template.getCardHeight(), getScale()), BufferedImage.TYPE_INT_ARGB);
 			Graphics2D g2 = getGraphics(bi);
 			g2 = setGraphicsHints(g2);
 			

--- a/src/legedit2/cardtype/ElementTextArea.java
+++ b/src/legedit2/cardtype/ElementTextArea.java
@@ -24,7 +24,6 @@ import org.w3c.dom.Node;
 import legedit2.card.Card;
 import legedit2.definitions.Icon;
 import legedit2.imaging.BoxBlurFilter;
-import legedit2.imaging.CustomCardMaker;
 import legedit2.imaging.GaussianFilter;
 
 public class ElementTextArea extends CustomElement {
@@ -82,7 +81,10 @@ public class ElementTextArea extends CustomElement {
 	{
 		if (getValue() != null)
 		{
-			BufferedImage bi = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
+			int cardWidth = template.getCardWidth();
+			int cardHeight = template.getCardHeight();
+			
+			BufferedImage bi = new BufferedImage(getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
 			Graphics2D g2 = getGraphics(bi);
 			g2 = setGraphicsHints(g2);
 			
@@ -201,7 +203,7 @@ public class ElementTextArea extends CustomElement {
 		    				{
 		    					y -= lastWordBreakHeight;
 		    				}
-			    			drawHeader(g2, headerStr.toUpperCase(), fontHeader, /*card.cardType.getBgColor()*/ Color.red, y, headerHeight, getPercentage(CustomCardMaker.cardWidth, 0.2d), headerIcon);
+			    			drawHeader(g2, headerStr.toUpperCase(), fontHeader, /*card.cardType.getBgColor()*/ Color.red, y, headerHeight, getPercentage(cardWidth, 0.2d), headerIcon);
 				    		y += headerHeight + metrics.getHeight() + getPercentage(metrics.getHeight(), 0.5d);
 		    			}
 //		    			else
@@ -348,7 +350,10 @@ public class ElementTextArea extends CustomElement {
 	{
 		if (getValue() != null)
 		{
-			BufferedImage bi = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
+			int cardWidth = template.getCardWidth();
+			int cardHeight = template.getCardHeight();
+
+			BufferedImage bi = new BufferedImage(getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
 			Graphics2D g2 = getGraphics(bi);
 			g2 = setGraphicsHints(g2);
 			
@@ -549,7 +554,7 @@ public class ElementTextArea extends CustomElement {
 	{
 		if (alignmentHorizontal.equals(ALIGNMENT.LEFT))
 		{
-			for (int i = 0; i < getPercentage(CustomCardMaker.cardWidth,getScale()); i++)
+			for (int i = 0; i < getPercentage(template.getCardWidth(),getScale()); i++)
 			{
 				if (getPolygon().contains(i, y))
 				{
@@ -567,7 +572,7 @@ public class ElementTextArea extends CustomElement {
 	{
 		if (alignmentVertical.equals(ALIGNMENT.TOP))
 		{
-			for (int i = 0; i < getPercentage(CustomCardMaker.cardHeight,getScale()); i++)
+			for (int i = 0; i < getPercentage(template.getCardHeight(),getScale()); i++)
 			{
 				if (getPolygon().contains(x, i))
 				{
@@ -585,7 +590,7 @@ public class ElementTextArea extends CustomElement {
 	{
 		if (alignmentHorizontal.equals(ALIGNMENT.LEFT))
 		{
-			for (int i = 0; i < getPercentage(CustomCardMaker.cardWidth,getScale()); i++)
+			for (int i = 0; i < getPercentage(template.getCardWidth(),getScale()); i++)
 			{
 				int ypos = getYStart(i);
 				if (ypos > -1)
@@ -687,11 +692,14 @@ public class ElementTextArea extends CustomElement {
 	
 	private void drawHeader(Graphics2D g, String header, Font font, Color color, int y, int height, int blurRadius, HeaderIcon headerIcon)
 	{
-		BufferedImage bi1 = new BufferedImage(getPercentage(CustomCardMaker.cardWidth, getScale()), getPercentage(CustomCardMaker.cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
+		int cardWidth = template.getCardWidth();
+		int cardHeight = template.getCardHeight();
+
+		BufferedImage bi1 = new BufferedImage(getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g2 = getGraphics(bi1);
 		
 		g2.setColor(color);
-		g2.fillRect(0, y, getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.8d), height);
+		g2.fillRect(0, y, getPercentage(getPercentage(cardWidth, getScale()), 0.8d), height);
     	
     	if (blurRadius > 0)
     	{
@@ -707,13 +715,13 @@ public class ElementTextArea extends CustomElement {
     	if (headerIcon != null && headerIcon.icon != null)
 	    {
 	    	BufferedImage bi = getIcon(headerIcon.icon, getPercentage(height, 1.9d), getPercentage(height, 1.9d));
-	    	int iconx = getPercentage(CustomCardMaker.cardWidth,getScale()) - getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.09d) - bi.getWidth() + (bi.getWidth() / 2);
+	    	int iconx = getPercentage(cardWidth, getScale()) - getPercentage(getPercentage(cardWidth, getScale()), 0.09d) - bi.getWidth() + (bi.getWidth() / 2);
 	    	int icony = y + (height / 2) - (bi.getWidth() / 2);
 	    	
 	    	g2.drawImage(bi, iconx, icony, null);
 	    }
     	
-    	BufferedImage bi2 = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
+    	BufferedImage bi2 = new BufferedImage(getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()), BufferedImage.TYPE_INT_ARGB);
 		Graphics2D g3 = getGraphics(bi2);	
 		
     	g3.setColor(Color.WHITE);
@@ -721,7 +729,7 @@ public class ElementTextArea extends CustomElement {
     	
     	g3 = setGraphicsHints(g3);
     	
-		g3.drawString(header, getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.04d), y + g.getFontMetrics(font).getHeight() - (g.getFontMetrics(font).getHeight() / 6));
+		g3.drawString(header, getPercentage(getPercentage(cardWidth, getScale()), 0.04d), y + g.getFontMetrics(font).getHeight() - (g.getFontMetrics(font).getHeight() / 6));
 		
 		if (headerIcon != null && headerIcon.value != null)
 		{
@@ -733,7 +741,7 @@ public class ElementTextArea extends CustomElement {
 			g3 = setGraphicsHints(g3);
 			
 			int stringLength = SwingUtilities.computeStringWidth(g.getFontMetrics(font), headerIcon.value.toUpperCase());
-			g3.drawString(headerIcon.value, getPercentage(CustomCardMaker.cardWidth,getScale()) - getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.09d) - stringLength + (stringLength / 2), y + g.getFontMetrics(font).getHeight() - (int)(g.getFontMetrics(font).getHeight() / 2.6d));
+			g3.drawString(headerIcon.value, getPercentage(cardWidth, getScale()) - getPercentage(getPercentage(cardWidth, getScale()), 0.09d) - stringLength + (stringLength / 2), y + g.getFontMetrics(font).getHeight() - (int)(g.getFontMetrics(font).getHeight() / 2.6d));
 			
 			font = originalFont;
 			g3.setFont(originalFont);
@@ -743,7 +751,7 @@ public class ElementTextArea extends CustomElement {
 		
 		drawUnderlay(bi2, g3, BufferedImage.TYPE_INT_ARGB, 0, 0, 5, true, 3);
 		
-		g3.drawString(header, getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.04d), y + g.getFontMetrics(font).getHeight() - (g.getFontMetrics(font).getHeight() / 6));
+		g3.drawString(header, getPercentage(getPercentage(cardWidth, getScale()), 0.04d), y + g.getFontMetrics(font).getHeight() - (g.getFontMetrics(font).getHeight() / 6));
 		
 		if (headerIcon != null && headerIcon.value != null)
 		{
@@ -753,7 +761,7 @@ public class ElementTextArea extends CustomElement {
 			g3.setFont(font);
 			g3 = setGraphicsHints(g3);
 			int stringLength = SwingUtilities.computeStringWidth(g.getFontMetrics(font), headerIcon.value.toUpperCase());
-			g3.drawString(headerIcon.value, getPercentage(CustomCardMaker.cardWidth,getScale()) - getPercentage(getPercentage(CustomCardMaker.cardWidth,getScale()), 0.09d) - stringLength + (stringLength / 2), y + g.getFontMetrics(font).getHeight() - (int)(g.getFontMetrics(font).getHeight() / 2.6d));
+			g3.drawString(headerIcon.value, getPercentage(cardWidth, getScale()) - getPercentage(getPercentage(cardWidth, getScale()), 0.09d) - stringLength + (stringLength / 2), y + g.getFontMetrics(font).getHeight() - (int)(g.getFontMetrics(font).getHeight() / 2.6d));
 			
 			font = originalFont;
 			g3.setFont(originalFont);
@@ -769,7 +777,7 @@ public class ElementTextArea extends CustomElement {
 	
 	private void drawUnderlay(BufferedImage bi, Graphics2D g, int type, int x, int y, int blurRadius, boolean doubleBlur, int expandBlackout)
 	{
-		BufferedImage blackout = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), type);
+		BufferedImage blackout = new BufferedImage(getPercentage(template.getCardWidth(), getScale()), getPercentage(template.getCardHeight(), getScale()), type);
     	getGraphics(blackout).drawImage(bi, x, y, null);
     	
     	blackout = blackoutImage(blackout);
@@ -815,7 +823,7 @@ public class ElementTextArea extends CustomElement {
 	
 	private BufferedImage expandBlackout(BufferedImage image, int expandBlackout)
 	{
-		BufferedImage expand = new BufferedImage(getPercentage(CustomCardMaker.cardWidth,getScale()), getPercentage(CustomCardMaker.cardHeight,getScale()), BufferedImage.TYPE_INT_ARGB);
+		BufferedImage expand = new BufferedImage(getPercentage(template.getCardWidth(), getScale()), getPercentage(template.getCardHeight(), getScale()), BufferedImage.TYPE_INT_ARGB);
 		
 		int width = image.getWidth();
         int height = image.getHeight();

--- a/src/legedit2/imaging/CustomCardMaker.java
+++ b/src/legedit2/imaging/CustomCardMaker.java
@@ -28,11 +28,6 @@ public class CustomCardMaker {
 	
 	private boolean debug = false;
 	
-	// 2.5 by 3.5 inches - Poker Size
-	public static int cardWidth = 750;
-	public static int cardHeight = 1050;
-	public static int dpi = 300;
-	
 	boolean exportImage = false;
 	public boolean exportToPNG = true;
 	
@@ -78,7 +73,8 @@ public class CustomCardMaker {
 		{
 			type = BufferedImage.TYPE_INT_ARGB;	
 		}
-	    BufferedImage image = new BufferedImage(getPercentage(cardWidth, getScale()), getPercentage(cardHeight, getScale()), type);
+
+		BufferedImage image = new BufferedImage(getPercentage(template.getCardWidth(), getScale()), getPercentage(template.getCardHeight(), getScale()), type);
 	    Graphics2D g = (Graphics2D)image.getGraphics();
 	    
 	    if (debug)
@@ -292,7 +288,7 @@ public class CustomCardMaker {
 	
 	private void drawUnderlay(BufferedImage bi, Graphics g, int type, int x, int y, int blurRadius, boolean doubleBlur, int expandBlackout, Color underlayColour)
 	{
-		BufferedImage blackout = new BufferedImage(cardWidth, cardHeight, type);
+		BufferedImage blackout = new BufferedImage(template.getCardWidth(), template.getCardHeight(), type);
     	blackout.getGraphics().drawImage(bi, x, y, null);
     	
     	blackout = blackoutImage(blackout, underlayColour);
@@ -333,7 +329,7 @@ public class CustomCardMaker {
 	
 	private BufferedImage expandBlackout(BufferedImage image, int expandBlackout, Color blackoutColor)
 	{
-		BufferedImage expand = new BufferedImage(cardWidth, cardHeight, BufferedImage.TYPE_INT_ARGB);
+		BufferedImage expand = new BufferedImage(template.getCardWidth(), template.getCardHeight(), BufferedImage.TYPE_INT_ARGB);
 		
 		int width = image.getWidth();
         int height = image.getHeight();
@@ -385,7 +381,7 @@ public class CustomCardMaker {
 	
 	private BufferedImage createRareBacking(int x, int y, int x2, int y2)
 	{
-		BufferedImage bi = new BufferedImage(cardWidth, cardHeight, BufferedImage.TYPE_INT_ARGB);
+		BufferedImage bi = new BufferedImage(template.getCardWidth(), template.getCardHeight(), BufferedImage.TYPE_INT_ARGB);
         Graphics g2 = bi.getGraphics();
         
         //System.out.println(x +":"+y+":"+x2+":"+y2+":"+(x2-x)+":"+(y2-y));
@@ -451,6 +447,9 @@ public class CustomCardMaker {
 	
 	private BufferedImage getFadedBackground(ImageIcon ii)
 	{
+		int cardWidth = template.getCardWidth();
+		int cardHeight = template.getCardHeight();
+		
 		BufferedImage bi = new BufferedImage(cardWidth, cardHeight, BufferedImage.TYPE_INT_ARGB);
 		Graphics g = bi.getGraphics();
 		g.drawImage(ii.getImage(), 0, 0, cardWidth, cardHeight, null);


### PR DESCRIPTION
The information was stored in a static location and was used globally for each card. Moved it into the base class CardType instead so that each template can have its own dimensions.