### PR TITLE
Improvements to banners

### DIFF
--- a/legedit/cardtypes/bindings/template.xml
+++ b/legedit/cardtypes/bindings/template.xml
@@ -4,7 +4,8 @@
 <template
  name="bindings"
  displayname="Bindings"
- group="bystanders"
+ deck="wound"
+ defaultsindeck="false"
  />
 
 <cardsize
@@ -45,7 +46,7 @@
  uppercase="true"
  alignment="left"
  x="100"
- y="730"
+ y="715"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"

--- a/legedit/cardtypes/bystander/template.xml
+++ b/legedit/cardtypes/bystander/template.xml
@@ -4,7 +4,9 @@
 <template
  name="bystander"
  displayname="Bystander"
- group="bystanders"
+ deck="bystanders"
+ defaultsindeck="true"
+ defaultcopies="1"
  />
 
 <cardsize
@@ -97,7 +99,7 @@
  uppercase="true"
  alignment="left"
  x="100"
- y="730"
+ y="715"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"

--- a/legedit/cardtypes/bystander_villain/template.xml
+++ b/legedit/cardtypes/bystander_villain/template.xml
@@ -4,7 +4,8 @@
 <template
  name="bystander_villain"
  displayname="Bystander Villain"
- group="bystanders"
+ deck="bystanders"
+ defaultsindeck="false"
  />
 
 <cardsize
@@ -97,7 +98,7 @@
  uppercase="true"
  alignment="left"
  x="100"
- y="730"
+ y="715"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"

--- a/legedit/cardtypes/bystander_wound/template.xml
+++ b/legedit/cardtypes/bystander_wound/template.xml
@@ -4,7 +4,8 @@
 <template
  name="bystander_wound"
  displayname="Bystander/Wound"
- group="bystanders"
+ deck="bystanders"
+ defaultsindeck="false"
  />
 
 <cardsize
@@ -93,7 +94,7 @@
  uppercase="true"
  alignment="left"
  x="100"
- y="730"
+ y="715"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"
@@ -112,7 +113,7 @@
  uppercase="true"
  alignment="left"
  x="100"
- y="725"
+ y="715"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"

--- a/legedit/cardtypes/hero_common/template.xml
+++ b/legedit/cardtypes/hero_common/template.xml
@@ -109,6 +109,8 @@
  subnameeditable="true"
  highlight="banner"
  highlightcolour="#111111"
+ bannerextratop="10"
+ bannerextrabottom="15"
  uppercase="true"
  alignment="center"
  x="375"

--- a/legedit/cardtypes/hero_common_transformed/template.xml
+++ b/legedit/cardtypes/hero_common_transformed/template.xml
@@ -109,6 +109,8 @@
  subnameeditable="true"
  highlight="banner"
  highlightcolour="#111111"
+ bannerextratop="10"
+ bannerextrabottom="15"
  uppercase="true"
  alignment="center"
  x="375"

--- a/legedit/cardtypes/hero_rare/template.xml
+++ b/legedit/cardtypes/hero_rare/template.xml
@@ -64,6 +64,8 @@
  subnameeditable="true"
  highlight="banner"
  highlightcolour="#111111"
+ bannerextratop="10"
+ bannerextrabottom="15"
  uppercase="true"
  alignment="center"
  x="375"

--- a/legedit/cardtypes/hero_rare_transformed/template.xml
+++ b/legedit/cardtypes/hero_rare_transformed/template.xml
@@ -64,6 +64,8 @@
  subnameeditable="true"
  highlight="banner"
  highlightcolour="#111111"
+ bannerextratop="10"
+ bannerextrabottom="15"
  uppercase="true"
  alignment="center"
  x="375"

--- a/legedit/cardtypes/hero_uncommon/template.xml
+++ b/legedit/cardtypes/hero_uncommon/template.xml
@@ -109,6 +109,8 @@
  subnameeditable="true"
  highlight="banner"
  highlightcolour="#111111"
+ bannerextratop="10"
+ bannerextrabottom="15"
  uppercase="true"
  alignment="center"
  x="375"

--- a/legedit/cardtypes/hero_uncommon_transformed/template.xml
+++ b/legedit/cardtypes/hero_uncommon_transformed/template.xml
@@ -109,6 +109,8 @@
  subnameeditable="true"
  highlight="banner"
  highlightcolour="#111111"
+ bannerextratop="10"
+ bannerextrabottom="15"
  uppercase="true"
  alignment="center"
  x="375"

--- a/legedit/cardtypes/recruitable_bystander/template.xml
+++ b/legedit/cardtypes/recruitable_bystander/template.xml
@@ -4,7 +4,8 @@
 <template
  name="recruitable_bystander"
  displayname="Recruitable Bystander"
- group="bystanders"
+ deck="bystanders"
+ defaultsindeck="false"
  />
 
 <cardsize
@@ -64,7 +65,7 @@
  uppercase="true"
  alignment="left"
  x="130"
- y="745"
+ y="735"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"

--- a/legedit/cardtypes/wound/template.xml
+++ b/legedit/cardtypes/wound/template.xml
@@ -4,7 +4,9 @@
 <template
  name="wound"
  displayname="Wound"
- group="bystanders"
+ deck="wound"
+ defaultsindeck="true"
+ defaultcopies="1"
  />
 
 <cardsize
@@ -45,7 +47,7 @@
  uppercase="true"
  alignment="left"
  x="100"
- y="730"
+ y="715"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"

--- a/legedit/cardtypes/wound_grevious/template.xml
+++ b/legedit/cardtypes/wound_grevious/template.xml
@@ -4,7 +4,7 @@
 <template
  name="wound_grevious"
  displayname="Wound (Grevious)"
- group="wound_binding"
+ deck="wound"
  defaultsindeck="false"
  />
 
@@ -104,7 +104,7 @@
  uppercase="true"
  alignment="left"
  x="70"
- y="725"
+ y="715"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"

--- a/legedit/cardtypes/wound_villain/template.xml
+++ b/legedit/cardtypes/wound_villain/template.xml
@@ -4,7 +4,6 @@
 <template
  name="wound_villain"
  displayname="Wound (Villain)"
- group="villain"
  deck="villain"
  defaultsindeck="false"
  />
@@ -107,7 +106,7 @@
  uppercase="true"
  alignment="left"
  x="100"
- y="730"
+ y="715"
  colour="#FFFFFF"
  textsize="60"
  subnamesize="40"

--- a/legedit/decktypes/bystanders.xml
+++ b/legedit/decktypes/bystanders.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xml>
+
+<structure
+ name="bystanders"
+ displayname="Bystanders"
+ group="bystanders"
+ nameeditable="false"
+ />
+
+</xml>
+

--- a/legedit/decktypes/wound.xml
+++ b/legedit/decktypes/wound.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xml>
+
+<structure
+ name="wound"
+ displayname="Wound"
+ group="wounds"
+ nameeditable="false"
+ />
+
+</xml>
+

--- a/src/legedit2/cardtype/CardType.java
+++ b/src/legedit2/cardtype/CardType.java
@@ -873,6 +873,16 @@ public class CardType extends ItemType implements Cloneable {
 				element.highlight = HIGHLIGHT.valueOf(node.getAttributes().getNamedItem("highlight").getNodeValue().toUpperCase());
 			}
 			
+			if (node.getAttributes().getNamedItem("bannerextratop") != null)
+			{
+				element.bannerExtraSizeTop = Integer.parseInt(node.getAttributes().getNamedItem("bannerextratop").getNodeValue());
+			}
+
+			if (node.getAttributes().getNamedItem("bannerextrabottom") != null)
+			{
+				element.bannerExtraSizeBottom = Integer.parseInt(node.getAttributes().getNamedItem("bannerextrabottom").getNodeValue());
+			}
+
 			if (node.getAttributes().getNamedItem("visible") != null)
 			{
 				element.visible = Boolean.parseBoolean(node.getAttributes().getNamedItem("visible").getNodeValue());


### PR DESCRIPTION
- Added the ability to add some bleed of the banner at its top and bottom (use the xml tags bannerextratop and bannerextrabottom). By default, ledEdit2 will assume they respectively value 10 and 15 if not specified. Used the new tags in the Hero templates as an example.
- Fixed some issues with the blur choice for highlights, it wasn't doing the whole thing for the card name. Especially annoying if changing the font/size of the card name.
- Reorganized some of the templates into Decks:
-- Wounds, Grevious Wounds and Bindings are now part of the same deck type: Wounds.
-- Bystanders, Bystanders Villains, Recruitable Bystanders and Bystanders Wounds are now part of the same deck type: Bystanders.
- Fixed some alignment issues for Wounds, Bindings, Grevious Wounds, Wound Villains, Bystanders, Bystander Villains, Bystander Wound and Recruitable Bystanders.